### PR TITLE
b-table: Adds "clicked" prop that run when row is clicked

### DIFF
--- a/lib/components/table.vue
+++ b/lib/components/table.vue
@@ -10,7 +10,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr v-for="(item,index) in _items" :key="items_key" :class="[item.state?'table-'+item.state:null]">
+        <tr v-for="(item,index) in _items" :key="items_key" :class="[item.state?'table-'+item.state:null]" @click="invokeClicked(item, index)">
             <td v-for="(field,key) in fields" :class="[field.class?field.class:null]">
                 <slot :name="key" :value="item[key]" :item="item" :index="index">{{item[key]}}</slot>
             </td>
@@ -49,6 +49,10 @@
         },
 
         props: {
+            clicked: {
+                type: Function,
+                default: null
+            },
             items: {
                 type: Array,
                 default: () => []
@@ -137,6 +141,11 @@
             }
         },
         methods: {
+            invokeClicked(item, index) {
+              if (this.clicked) {
+                this.clicked(item, index)
+              }
+            },
             headClick(field, key) {
                 if (!field.sortable) {
                     this.sortBy = null;


### PR DESCRIPTION
When the row of a table is clicked, we would like to perform a redirect.

Allow the user to pass in a function that will be executed when the row
is clicked. It's up to the user to add the redirection within the method
as the method is passed the current item and its index.